### PR TITLE
Get only last 500 blocks

### DIFF
--- a/components/chain.tsx
+++ b/components/chain.tsx
@@ -22,7 +22,7 @@ function ShortBlock({ block, chainLength, i }) {
 
   return (
     <tr>
-      <td>{chainLength - 1 - i}</td>
+      <td>{-i}</td>
       <td>
         <BlockLink blockid={id(block)} short />
       </td>
@@ -46,7 +46,7 @@ export default function Chain({ chain }) {
 
       <table>
         <tr>
-          <th>Height</th>
+          <th>Relative<br/>Height</th>
           <th>Hash</th>
           <th>Age</th>
           <th>Time</th>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "marabu-explorer",
+  "name": "Marabu Explorer",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
The explorer is currently down since the chain is too long. I propose only displaying the last 500 blocks of the chain. If we have more time maybe we could add the option to "fetch more blocks" dynamically as you start scrolling down. For now, this at least makes sure the explorer works again.